### PR TITLE
Add support for gnome 46

### DIFF
--- a/windowIsReady_Remover@nunofarruca@gmail.com/metadata.json
+++ b/windowIsReady_Remover@nunofarruca@gmail.com/metadata.json
@@ -4,7 +4,8 @@
   "name": "Window Is Ready - Notification Remover", 
   "license": "Apache-2.0",
   "shell-version": [
-    "45"
+    "45",
+    "46"
   ],
   "url": "https://github.com/nunofarruca/WindowIsReady_Remover", 
   "uuid": "windowIsReady_Remover@nunofarruca@gmail.com", 


### PR DESCRIPTION
The extension is out of the box compatible with Gnome 46. So just tell Gnome that it also works on 46.