### PR TITLE
Refactor signal handling methods

### DIFF
--- a/windowIsReady_Remover@nunofarruca@gmail.com/extension.js
+++ b/windowIsReady_Remover@nunofarruca@gmail.com/extension.js
@@ -14,13 +14,17 @@ export default class windowIsReadyRemover {
         this.unblockSignal('window-marked-urgent');
     }
 
-    blockSignal(id) {
-        let signalId = GObject.signal_handler_find(global.display, { signalId: id });
-        GObject.signal_handler_block(global.display, signalId);
+    getSignalHandlerId(signalId) {
+        return GObject.signal_handler_find(global.display, { signalId });
     }
 
-    unblockSignal(id){
-        let signalId = GObject.signal_handler_find(global.display, { signalId: id });
-        GObject.signal_handler_unblock(global.display, signalId);
+    blockSignal(signalId) {
+        const signalHandlerId = getSignalHandlerId(signalId);
+        GObject.signal_handler_block(global.display, signalHandlerId);
+    }
+
+    unblockSignal(signalId){
+        const signalHandlerId = getSignalHandlerId(signalId);
+        GObject.signal_handler_unblock(global.display, signalHandlerId);
     }
 }

--- a/windowIsReady_Remover@nunofarruca@gmail.com/extension.js
+++ b/windowIsReady_Remover@nunofarruca@gmail.com/extension.js
@@ -19,12 +19,12 @@ export default class windowIsReadyRemover {
     }
 
     blockSignal(signalId) {
-        const signalHandlerId = getSignalHandlerId(signalId);
+        const signalHandlerId = this.getSignalHandlerId(signalId);
         GObject.signal_handler_block(global.display, signalHandlerId);
     }
 
     unblockSignal(signalId){
-        const signalHandlerId = getSignalHandlerId(signalId);
+        const signalHandlerId = this.getSignalHandlerId(signalId);
         GObject.signal_handler_unblock(global.display, signalHandlerId);
     }
 }


### PR DESCRIPTION
Moved `signal_handler_find` out to its own method for reuse in `blockSignal` and `unblockSignal`.